### PR TITLE
Add ammo reload mechanic

### DIFF
--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -26,6 +26,7 @@ type Game struct {
 	mobs         []*Mob
 	projectiles  []*Projectile
 	spawnCounter int
+	hud          *HUD
 }
 
 // NewGame creates a new instance of the Game.
@@ -44,6 +45,7 @@ func NewGame() *Game {
 	tx, ty := tilePosition(2, 16)
 	tower := NewTower(g, float64(tx+16), float64(ty+16))
 	g.towers = []*Tower{tower}
+	g.hud = NewHUD(g)
 	return g
 }
 
@@ -101,6 +103,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 	for _, m := range g.mobs {
 		m.Draw(g.screen)
+	}
+
+	if g.hud != nil {
+		g.hud.Draw(g.screen)
 	}
 
 	highlightHoverAndClickAndDrag(g.screen, "line")

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -1,1 +1,35 @@
 package game
+
+import (
+	"fmt"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+// HUD displays simple text information about the tower state.
+type HUD struct {
+	game *Game
+}
+
+// NewHUD creates a new HUD bound to the given game.
+func NewHUD(g *Game) *HUD {
+	return &HUD{game: g}
+}
+
+// Draw renders ammo count and reload prompts.
+func (h *HUD) Draw(screen *ebiten.Image) {
+	if len(h.game.towers) == 0 {
+		return
+	}
+	t := h.game.towers[0]
+	ammo := fmt.Sprintf("Ammo: %d/%d", t.ammo, t.ammoCapacity)
+	ebitenutil.DebugPrintAt(screen, ammo, 10, 40)
+	if t.reloading {
+		prompt := fmt.Sprintf("Reload in: %d", t.reloadTimer)
+		if t.reloadTimer <= 0 {
+			prompt = fmt.Sprintf("Type '%c'", t.reloadLetter)
+		}
+		ebitenutil.DebugPrintAt(screen, prompt, 10, 52)
+	}
+}

--- a/v1/internal/game/input.go
+++ b/v1/internal/game/input.go
@@ -9,13 +9,15 @@ type InputHandler interface {
 }
 
 type Input struct {
-	quit bool // Whether the game should quit
+	quit  bool   // Whether the game should quit
+	typed []rune // Characters typed this frame
 }
 
 // NewInput creates a new Input instance with default values.
 func NewInput() *Input {
 	return &Input{
-		quit: false, // Default to not quitting
+		quit:  false, // Default to not quitting
+		typed: nil,
 	}
 }
 
@@ -24,14 +26,21 @@ func (i *Input) Update() {
 	if ebiten.IsKeyPressed(ebiten.KeyEscape) {
 		i.quit = true
 	}
+	i.typed = ebiten.AppendInputChars(i.typed[:0])
 }
 
 // Reset resets the Input state to its default values.
 func (i *Input) Reset() {
 	i.quit = false // Reset quit state
+	i.typed = i.typed[:0]
 }
 
 // Quit returns whether the game should quit.
 func (i *Input) Quit() bool {
 	return i.quit
+}
+
+// TypedChars returns any characters typed since the last Update call.
+func (i *Input) TypedChars() []rune {
+	return i.typed
 }


### PR DESCRIPTION
## Summary
- add typed character capture to Input
- show ammo/reload prompts in HUD
- implement ammo capacity and reload system for towers
- display HUD in the main Game

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f670e1d9883279262517e23c3d3dd