### PR TITLE
Enhance tower cooldown and mob pathing

### DIFF
--- a/v1/internal/game/content.go
+++ b/v1/internal/game/content.go
@@ -50,8 +50,19 @@ func generateBackground() *ebiten.Image {
 }
 
 func generateBaseImage() *ebiten.Image {
-	img := ebiten.NewImage(64, 64)
-	img.Fill(color.RGBA{100, 100, 100, 255})
+	w, h := 96, 64
+	img := ebiten.NewImage(w, h)
+	clr := color.RGBA{0, 128, 128, 255}
+	topWidth := 40
+	bottomWidth := 80
+	for y := 0; y < h; y++ {
+		t := float64(y) / float64(h-1)
+		rowW := int(float64(topWidth) + (float64(bottomWidth-topWidth) * t))
+		startX := w/2 - rowW/2
+		for x := startX; x < startX+rowW; x++ {
+			img.Set(x, y, clr)
+		}
+	}
 	return img
 }
 

--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -99,7 +99,10 @@ func (g *Game) Update() error {
 	for i := 0; i < len(g.mobs); {
 		m := g.mobs[i]
 		m.Update()
-		if m.pos.X < g.base.pos.X {
+		bx, by, bw, bh := g.base.Bounds()
+		dx := m.pos.X - float64(bx+bw/2)
+		dy := m.pos.Y - float64(by+bh/2)
+		if math.Hypot(dx, dy) < float64(m.width/2+bw/2) {
 			g.base.Damage(1)
 			m.alive = false
 		}
@@ -164,7 +167,7 @@ func drawBackgroundTilemap(screen *ebiten.Image) {
 func (g *Game) spawnMob() {
 	row := rand.Intn(32)
 	x, y := tilePosition(59, row)
-	m := NewMob(float64(x+16), float64(y+16))
+	m := NewMob(float64(x+16), float64(y+16), g.base)
 	g.mobs = append(g.mobs, m)
 }
 

--- a/v1/internal/game/mob.go
+++ b/v1/internal/game/mob.go
@@ -1,15 +1,19 @@
 package game
 
+import "math"
+
 // Mob represents a basic enemy moving left.
 type Mob struct {
 	BaseEntity
 	speed      float64
 	animTicker int
 	alive      bool
+	vx, vy     float64
+	target     *Base
 }
 
 // NewMob returns a new mob at the given position.
-func NewMob(x, y float64) *Mob {
+func NewMob(x, y float64, target *Base) *Mob {
 	w, h := ImgMobA.Bounds().Dx(), ImgMobA.Bounds().Dy()
 	return &Mob{
 		BaseEntity: BaseEntity{
@@ -20,26 +24,34 @@ func NewMob(x, y float64) *Mob {
 			frameAnchorX: float64(w) / 2,
 			frameAnchorY: float64(h) / 2,
 		},
-		speed: 1,
-		alive: true,
+		speed:  1,
+		alive:  true,
+		target: target,
 	}
 }
 
 // Update moves the mob and handles animation.
 func (m *Mob) Update() {
-	m.pos.X -= m.speed
+	if m.target != nil {
+		dx := m.target.pos.X - m.pos.X
+		dy := m.target.pos.Y - m.pos.Y
+		dist := math.Hypot(dx, dy)
+		if dist != 0 {
+			m.vx = dx / dist * m.speed
+			m.vy = dy / dist * m.speed
+		}
+	}
+	m.pos.X += m.vx
+	m.pos.Y += m.vy
 	m.animTicker++
 	if m.animTicker%30 < 15 {
 		m.frame = ImgMobA
 	} else {
 		m.frame = ImgMobB
 	}
-	if m.pos.X < -float64(m.width) {
-		m.alive = false
-	}
 }
 
 // Velocity returns the mob's current velocity components.
 func (m *Mob) Velocity() (vx, vy float64) {
-	return -m.speed, 0
+	return m.vx, m.vy
 }

--- a/v1/internal/game/projectile_test.go
+++ b/v1/internal/game/projectile_test.go
@@ -3,7 +3,7 @@ package game
 import "testing"
 
 func TestProjectileIntercept(t *testing.T) {
-	mob := NewMob(200, 100)
+	mob := NewMob(200, 100, nil)
 	p := NewProjectile(100, 100, mob)
 	for i := 0; i < 200 && mob.alive && p.alive; i++ {
 		mob.Update()

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -61,6 +61,7 @@ func (t *Tower) Update() {
 				t.ammo++
 				if t.ammo >= t.ammoCapacity {
 					t.reloading = false
+					t.cooldown = 0
 				} else {
 					t.reloadTimer = t.reloadTime
 					if rand.Intn(2) == 0 {
@@ -108,6 +109,7 @@ func (t *Tower) Update() {
 func (t *Tower) startReload() {
 	t.reloading = true
 	t.reloadTimer = t.reloadTime
+	t.cooldown = 0
 	if rand.Intn(2) == 0 {
 		t.reloadLetter = 'f'
 	} else {
@@ -131,11 +133,14 @@ func generateRangeImage(radius float64) *ebiten.Image {
 	r := int(radius)
 	img := ebiten.NewImage(r*2, r*2)
 	clr := color.RGBA{0, 255, 0, 80}
+	rr := r * r
+	inner := (r - 1) * (r - 1)
 	for x := 0; x < r*2; x++ {
 		for y := 0; y < r*2; y++ {
 			dx := x - r
 			dy := y - r
-			if dx*dx+dy*dy <= r*r {
+			d := dx*dx + dy*dy
+			if d <= rr && d >= inner {
 				img.Set(x, y, clr)
 			}
 		}


### PR DESCRIPTION
## Summary
- mobs chase the base instead of moving left
- add teal trapezoid base sprite
- outline the tower range indicator
- reset tower cooldown when reloading
- adjust projectile test for new constructor

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f6a33a64c8327bfa0f7406a0d1f15