### PR TITLE
Improve base gameplay and debug info

### DIFF
--- a/v1/internal/game/base.go
+++ b/v1/internal/game/base.go
@@ -1,6 +1,9 @@
 package game
 
 // Base represents the player's base that mobs try to destroy.
+const BaseStartingHealth = 10
+
+// Base represents the player's base that mobs try to destroy.
 type Base struct {
 	BaseEntity
 	health int
@@ -19,7 +22,7 @@ func NewBase(x, y float64) *Base {
 			frameAnchorY: float64(h) / 2,
 			static:       true,
 		},
-		health: 100,
+		health: BaseStartingHealth,
 	}
 }
 
@@ -34,4 +37,9 @@ func (b *Base) Damage(amount int) {
 // Health returns the current health of the base.
 func (b *Base) Health() int {
 	return b.health
+}
+
+// Alive reports whether the base still has health remaining.
+func (b *Base) Alive() bool {
+	return b.health > 0
 }

--- a/v1/internal/game/game.go
+++ b/v1/internal/game/game.go
@@ -26,6 +26,7 @@ type Game struct {
 	projectiles []*Projectile
 	base        *Base
 	hud         *HUD
+	gameOver    bool
 
 	currentWave   int
 	spawnInterval int
@@ -69,6 +70,10 @@ func (g *Game) Update() error {
 
 	if g.input.Quit() {
 		return ebiten.Termination
+	}
+
+	if g.gameOver {
+		return nil
 	}
 
 	if g.mobsToSpawn > 0 {
@@ -116,6 +121,10 @@ func (g *Game) Update() error {
 		i++
 	}
 
+	if !g.base.Alive() {
+		g.gameOver = true
+	}
+
 	return nil
 }
 
@@ -123,6 +132,12 @@ func (g *Game) Update() error {
 func (g *Game) Draw(screen *ebiten.Image) {
 	g.screen.Clear()
 	drawBackgroundTilemap(g.screen)
+
+	if g.gameOver {
+		ebitenutil.DebugPrintAt(g.screen, "Game Over", 900, 540)
+		g.renderFrame(screen)
+		return
+	}
 
 	g.base.Draw(g.screen)
 

--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -32,4 +32,10 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 		}
 		ebitenutil.DebugPrintAt(screen, prompt, 10, 52)
 	}
+
+	base := fmt.Sprintf("Base HP: %d", h.game.base.Health())
+	ebitenutil.DebugPrintAt(screen, base, 10, 28)
+
+	wave := fmt.Sprintf("Wave %d | SpawnTicker %d/%d | ToSpawn %d | Mobs %d | Proj %d", h.game.currentWave, h.game.spawnTicker, h.game.spawnInterval, h.game.mobsToSpawn, len(h.game.mobs), len(h.game.projectiles))
+	ebitenutil.DebugPrintAt(screen, wave, 10, 64)
 }

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -38,12 +38,12 @@ func NewTower(g *Game, x, y float64) *Tower {
 			frameAnchorY: float64(h) / 2,
 			static:       true,
 		},
-		rate:         60,
+		rate:         100,
 		rangeDst:     300,
 		game:         g,
 		ammoCapacity: 5,
 		ammo:         5,
-		reloadTime:   60,
+		reloadTime:   0,
 	}
 	t.rangeImg = generateRangeImage(t.rangeDst)
 	return t
@@ -61,9 +61,8 @@ func (t *Tower) Update() {
 				t.ammo++
 				if t.ammo >= t.ammoCapacity {
 					t.reloading = false
-					t.cooldown = 0
+					t.cooldown = t.rate
 				} else {
-					t.reloadTimer = t.reloadTime
 					if rand.Intn(2) == 0 {
 						t.reloadLetter = 'f'
 					} else {


### PR DESCRIPTION
## Summary
- add starting base health constant and alive check
- show base health and wave info in HUD
- add game over state and lose screen
- tweak tower rate, reload mechanics and cooldown

## Testing
- `go test ./...` *(fails: missing X11 libs)*

------
https://chatgpt.com/codex/tasks/task_e_683f6f7ba7108327a3df88986d18c507