### PR TITLE
Add jam, gold, and pause mechanics

### DIFF
--- a/v1/internal/game/hud.go
+++ b/v1/internal/game/hud.go
@@ -31,11 +31,13 @@ func (h *HUD) Draw(screen *ebiten.Image) {
 			prompt = fmt.Sprintf("Type '%c'", t.reloadLetter)
 		}
 		ebitenutil.DebugPrintAt(screen, prompt, 10, 52)
+	} else if t.jammed {
+		ebitenutil.DebugPrintAt(screen, "Jammed! backspace", 10, 52)
 	}
 
 	base := fmt.Sprintf("Base HP: %d", h.game.base.Health())
 	ebitenutil.DebugPrintAt(screen, base, 10, 28)
 
-	wave := fmt.Sprintf("Wave %d | SpawnTicker %d/%d | ToSpawn %d | Mobs %d | Proj %d", h.game.currentWave, h.game.spawnTicker, h.game.spawnInterval, h.game.mobsToSpawn, len(h.game.mobs), len(h.game.projectiles))
+	wave := fmt.Sprintf("Wave %d | Gold %d | Mobs %d", h.game.currentWave, h.game.gold, len(h.game.mobs))
 	ebitenutil.DebugPrintAt(screen, wave, 10, 64)
 }

--- a/v1/internal/game/input.go
+++ b/v1/internal/game/input.go
@@ -1,24 +1,31 @@
 package game
 
-import "github.com/hajimehoshi/ebiten/v2"
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
 
 type InputHandler interface {
 	TypedChars() []rune // TypedChars returns any characters typed since the last Update call
-	Update()    // Update processes input events and updates the Input state
-	Reset()     // Reset resets the Input state to its default values
-	Quit() bool // Quit returns whether the game should quit
+	Update()            // Update processes input events and updates the Input state
+	Reset()             // Reset resets the Input state to its default values
+	Quit() bool         // Quit returns whether the game should quit
 }
 
 type Input struct {
-	quit  bool   // Whether the game should quit
-	typed []rune // Characters typed this frame
+	quit      bool   // Whether the game should quit
+	typed     []rune // Characters typed this frame
+	backspace bool   // Whether backspace was pressed this frame
+	space     bool   // Whether space was pressed this frame
 }
 
 // NewInput creates a new Input instance with default values.
 func NewInput() *Input {
 	return &Input{
-		quit:  false, // Default to not quitting
-		typed: nil,
+		quit:      false, // Default to not quitting
+		typed:     nil,
+		backspace: false,
+		space:     false,
 	}
 }
 
@@ -28,12 +35,16 @@ func (i *Input) Update() {
 		i.quit = true
 	}
 	i.typed = ebiten.AppendInputChars(i.typed[:0])
+	i.backspace = inpututil.IsKeyJustPressed(ebiten.KeyBackspace)
+	i.space = inpututil.IsKeyJustPressed(ebiten.KeySpace)
 }
 
 // Reset resets the Input state to its default values.
 func (i *Input) Reset() {
 	i.quit = false // Reset quit state
 	i.typed = i.typed[:0]
+	i.backspace = false
+	i.space = false
 }
 
 // Quit returns whether the game should quit.
@@ -44,4 +55,14 @@ func (i *Input) Quit() bool {
 // TypedChars returns any characters typed since the last Update call.
 func (i *Input) TypedChars() []rune {
 	return i.typed
+}
+
+// Backspace reports if backspace was pressed since the last Update call.
+func (i *Input) Backspace() bool {
+	return i.backspace
+}
+
+// Space reports if the space bar was pressed since the last Update call.
+func (i *Input) Space() bool {
+	return i.space
 }


### PR DESCRIPTION
## Summary
- extend input handling for space and backspace keys
- allow towers to reload on `r` and jam on wrong key
- show jammed state and gold in HUD
- track gold drops and support pausing the game

## Testing
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f7979f0788327ab676c7954df1346