### PR TITLE
Enable partial reload and refresh docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -24,6 +24,7 @@
 - Turret targets the closest mob of the letter typed.
 - Mobs drop gold when killed.
 - Friendly units will collect the gold and bring it to the base.
+- Reload any missing ammo by typing the prompted letter (`F` or `J`). A wrong key jams the turret until backspace is pressed.
 
 ### Shop Mode: Buy upgrades with collected gold
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,6 @@ Code should be formatted with `gofmt` and accompanied by unit tests when possibl
 ## Automation
 Custom prompts in `.github/prompts` and guidelines in `.github/instructions` are used with GitHub Copilot to streamline development and reduce bugs.
 
+## Reloading Mechanics
+The tower now accepts reload input whenever its magazine isn't full. Once ammo drops below capacity a prompt will show the letter to type (`F` or `J`). Typing the correct letter refills one round and another prompt will appear until the magazine is full. Mistyped letters jam the weapon and require a backspace to clear.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,3 +37,10 @@ A keyboard-only base defense game where players strategically place towers to de
 ## Tech Tree Mechanics
 
 Branches unlock based on letter access. For example, advanced weapons become available once the player can type the required letters.
+
+## Additional Ideas
+
+- Weather effects that alter projectile speed or visibility.
+- Escort missions where caravans must be protected as they cross the map.
+- Endless mode with scaling difficulty and online leaderboards.
+- Support for custom key layouts and alternate keyboard languages.

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 A high-level plan for implementing the core gameplay described in `ROADMAP.md`.
 
 - [ ] Create wave system that spawns enemy units marching toward the tower.
-- [ ] Allow towers to auto-fire and require manual reload via typed sequences.
+ - [ ] Allow towers to auto-fire and reload whenever ammo is below full using the new letter prompts.
 - [ ] Track typing accuracy and speed to modify reload time and score multiplier.
 - [ ] Implement progressive letter unlocking starting with the home row keys.
 - [ ] Add scoring system and display wave survival statistics.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ The prototype displays a 60x32 tile grid. Features include:
 - Tile highlighting under the cursor, with click-and-drag support for rectangle, circle, or line shapes.
 - Right-click to place house tiles that persist on the grid.
 - Simple input handler that closes the window on <kbd>Esc</kbd>.
+- Towers can be reloaded at any time once their magazines aren't full. The HUD shows either `F` or `J` as the next letter to type.
 
 These mechanics are a foundation for a larger typing defense game. `NOTES.md` outlines future ideas such as shooting enemies with typed characters and purchasing upgrades.
 

--- a/v1/internal/game/tower.go
+++ b/v1/internal/game/tower.go
@@ -77,13 +77,8 @@ func (t *Tower) Update() {
 		return
 	}
 
-	if !t.reloading {
-		for _, r := range typed {
-			if unicode.ToLower(r) == 'r' && t.ammo < t.ammoCapacity {
-				t.startReload()
-				return
-			}
-		}
+	if !t.reloading && t.ammo < t.ammoCapacity {
+		t.startReload()
 	}
 
 	if t.reloading {
@@ -111,11 +106,6 @@ func (t *Tower) Update() {
 				return
 			}
 		}
-		return
-	}
-
-	if t.ammo <= 0 {
-		t.startReload()
 		return
 	}
 


### PR DESCRIPTION
## Summary
- trigger reloading whenever the magazine isn't full
- document new reload behavior in the game notes and README files
- update TODO and ROADMAP with additional ideas

## Testing
- `gofmt -w internal/game/tower.go`
- `go test ./...` *(fails: missing X11 libs)*

------
https://chatgpt.com/codex/tasks/task_e_683f8a6382ec8327ac5ef48dc31c3240